### PR TITLE
change index default properties ALLOW_ROW_LOCKS, ALLOW_PAGE_LOCKS and…

### DIFF
--- a/properties_pane/defaultData.json
+++ b/properties_pane/defaultData.json
@@ -17,10 +17,15 @@
 			"constrCheck": true,
 			"constrEnforceUpserts": true,
 			"constrEnforceReplication": true
+		},
+		"Indxs": {
+			"ALLOW_ROW_LOCKS": true,
+			"ALLOW_PAGE_LOCKS": true
 		}
 	},
 	"field": {
-		"name": "New column"
+		"name": "New column",
+		"clustered": true
 	},
 	"patternField": {
 		"name": "^[a-zA-Z0-9_.-]+$"


### PR DESCRIPTION
Changed default properties ALLOW_ROW_LOCKS, ALLOW_PAGE_LOCKS , CLUSTERED because it is enabled by default

https://docs.microsoft.com/en-us/sql/t-sql/statements/alter-table-index-option-transact-sql?view=sql-server-ver15
https://docs.microsoft.com/en-us/sql/relational-databases/tables/create-primary-keys?view=sql-server-ver15